### PR TITLE
2026-04-11 minor release updates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,17 @@
+2.1.0 (2026-04-11)
+==================
+
+- Replace queues with deques for a simpler interface, allowing use of
+  ``.append()`` and ``.extend()`` methods for requests and responses
+- Add ``.json()`` convenience function to request objects
+- Add ``.responses`` property to compliment ``.requests`` property
+- Add ``keyAlgorithm`` arg to ``createSelfSignedCert`` to allow for
+  non-RSA keys, including post quantum algorithms like mldsa65
+- Remove unnecessary content check for CONNECT method
+- Deprecate ``.queueResponse`` method
+- Update tests
+- Update docs
+
 2.0.6 (2026-04-06)
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Spoof 👻
    ... import spoof
    ...
    ... with spoof.HTTPServer() as httpd:
-   ...     httpd.queueResponse([200, [], "This is Spoof 👻👋"])
+   ...     httpd.responses.append([200, [], "This is Spoof 👻👋"])
    ...     requests.get(httpd.url).text
    ...     httpd.requests
    ...
@@ -43,28 +43,35 @@ whatever responses are queued, or a default response if the queue is empty.
 Why would I want this?
 ======================
 Spoof is all about enabling test-driven development (and refactoring) of
-HTTP client code. Have you ever felt gross patching a client library to
+HTTP client code. Have you ever felt icky patching a client library to
 write tests? Ever been burned by this? Ever wanted to refactor a client
 library, but had no way to prove functionality apart from doing live
-integration testing? If you answered yes to any of the above, Spoof is
-for you.
+integration testing? If you answered yes to any of the above, Spoof might
+be for you.
 
-Compatibility
-=============
+Spoof HTTP servers run in a single background thread, so request and
+response order should be predictable. Tests using Spoof should be able
+to use the same fixtures, in the same order, and get the same results.
+
+Installation and Compatibility
+==============================
+
+Spoof is available on PyPI:
+
+.. code-block:: console
+
+   $ python -m pip install spoof
+
 Spoof is tested on Python 3.10 to 3.14, leverages the ``http.server`` module
-included in the standard library, and has no external dependencies. It may
-work on older versions of Python, but this is not supported.
+included in the Python standard library, and has no external dependencies.
+It may work on older versions of Python, but this is not supported.
 
 Multiple Spoof HTTP servers can be run concurrently, and by default, the port
-number is the next available unused port.  With OpenSSL installed, Spoof can
-also provide an SSL/TLS HTTP server.  IPv6 is fully supported.
+number is the next available unused port. With OpenSSL installed, Spoof can
+also provide an SSL/TLS HTTP server. HTTP proxying and IPv6 are also supported.
 
-Spoof HTTP servers run in a single background thread, so request and response
-order should be predictable. Tests should be able to use the same fixtures,
-in the same order, and get the same results.
-
-``SpoofRequestEnv`` instances
-=============================
+Request instances
+=================
 Spoof captures each request as a ``namedtuple`` with the following properties:
 
 +-------------------------+----------------------------------------------+
@@ -79,6 +86,8 @@ Spoof captures each request as a ``namedtuple`` with the following properties:
 | contentType             | Value of Content-Type header, if present     |
 +-------------------------+----------------------------------------------+
 | headers                 | ``http.client.HTTPMessage`` object of headers|
++-------------------------+----------------------------------------------+
+| json()                  | Convenience to call ``json.loads`` on content|
 +-------------------------+----------------------------------------------+
 | method                  | Request method (e.g. GET, POST, HEAD)        |
 +-------------------------+----------------------------------------------+
@@ -95,6 +104,39 @@ Spoof captures each request as a ``namedtuple`` with the following properties:
 | uri                     | Raw URI path and query string, if present    |
 +-------------------------+----------------------------------------------+
 
+Example with request properties:
+
+.. code-block:: python
+
+   >>> import requests
+   ... import spoof
+   ...
+   ... with spoof.HTTPServer() as httpd:
+   ...     httpd.defaultResponse = [200, [], None]
+   ...     [requests.get(httpd.url + path) for path in ["/a", "/b", "/c"]]
+   ...     [f"{r.method} {r.path} {r.protocol}" for r in httpd.requests]
+   ...
+   [<Response [200]>, <Response [200]>, <Response [200]>]
+   ['GET /a HTTP/1.1', 'GET /b HTTP/1.1', 'GET /c HTTP/1.1']
+
+Response format
+===============
+
+Spoof expects responses to have the following format:
+
+.. code-block:: python
+
+   [httpStatus, [(headerName1, value1), (headerName2, value2)], content]
+
+   # no content (Content-Length header is *not* sent if content is None)
+   [200, [], None]
+
+   # utf-8 content
+   [200, [], "This is Spoof 👻👋"]
+
+   # bytes content
+   [200, [("Content-Type", "application/json")], b'{"success": true }']
+
 Queued responses
 ================
 Queue multiple responses, verify content, and request paths:
@@ -105,11 +147,10 @@ Queue multiple responses, verify content, and request paths:
    import spoof
 
    with spoof.HTTPServer() as httpd:
-       responses = [
-           [200, [("Content-Type", "application/json")], '{"id": 1111}'],
-           [200, [("Content-Type", "application/json")], '{"id": 2222}'],
-       ]
-       httpd.queueResponse(*responses)
+       httpd.responses.extend([
+           [200, [("Content-Type", "application/json")], b'{"id": 1111}'],
+           [200, [("Content-Type", "application/json")], b'{"id": 2222}'],
+       ])
        httpd.defaultResponse = [404, [], "Not found"]
 
        assert requests.get(httpd.url + "/path").json() == {"id": 1111}
@@ -142,10 +183,10 @@ Test queued response with a self-signed SSL/TLS certificate:
 
    with spoof.SelfSignedSSLContext() as selfSigned:
        with spoof.HTTPServer(sslContext=selfSigned.sslContext) as httpd:
-           httpd.queueResponse([200, [], "No self-signed cert warning!"])
+           httpd.responses.append([200, [], "No self-signed cert warning!"])
            response = requests.get(httpd.url, verify=selfSigned.certFile)
 
-           assert response.content == b"No self-signed cert warning!"
+           assert response.text == "No self-signed cert warning!"
 
 If setting the ``verify`` option in ``requests`` isn't workable, the
 ``REQUESTS_CA_BUNDLE`` or ``CURL_CA_BUNDLE`` environment variables can be
@@ -160,10 +201,25 @@ set to the path of the self-signed certificate to silence SSL/TLS errors:
    with spoof.SelfSignedSSLContext() as selfSigned:
        with spoof.HTTPServer(sslContext=selfSigned.sslContext) as httpd:
            os.environ["REQUESTS_CA_BUNDLE"] = selfSigned.certFile
-           httpd.queueResponse([200, [], "No self-signed cert warning!"])
+           httpd.responses.append([200, [], "No self-signed cert warning!"])
            response = requests.get(httpd.url)
 
-           assert response.content == b"No self-signed cert warning!"
+           assert response.text == "No self-signed cert warning!"
+
+If OpenSSL 3.5.0 or later is installed, Post-Quantum Cryptography (PQC)
+key algorithms can be used:
+
+.. code-block:: python
+
+   import requests
+   import spoof
+
+   with spoof.SelfSignedSSLContext(keyAlgorithm="mldsa65") as selfSigned:
+       with spoof.HTTPServer(sslContext=selfSigned.sslContext) as httpd:
+           httpd.responses.append([200, [], "TLS with PQC Key Algorithm"])
+           response = requests.get(httpd.url, verify=selfSigned.certFile)
+
+           assert response.text == "TLS with PQC Key Algorithm"
 
 Proxy Mode
 ==========
@@ -211,7 +267,7 @@ only listen on IPv6 sockets.
    ... import spoof
    ...
    ... with spoof.HTTPServer(host="::1") as httpd:
-   ...     httpd.queueResponse([200, [], "This is Spoof on IPv6 👀"])
+   ...     httpd.responses.append([200, [], "This is Spoof on IPv6 👀"])
    ...     requests.get(httpd.url).text
    ...     httpd.url
    ...
@@ -224,7 +280,7 @@ only listen on IPv6 sockets.
    ... import spoof
    ...
    ... with spoof.HTTPServer6(host="localhost") as httpd:
-   ...     httpd.queueResponse([200, [], "This is also Spoof on IPv6 👀"])
+   ...     httpd.responses.append([200, [], "This is also Spoof on IPv6 👀"])
    ...     requests.get(httpd.url).text
    ...     httpd.url
    ...

--- a/src/spoof.py
+++ b/src/spoof.py
@@ -1,7 +1,8 @@
 import collections
+import functools
 import http.server as BaseHTTPServer
+import json
 import os
-import queue as Queue
 import re
 import select
 import socket
@@ -35,10 +36,11 @@ class HTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler, object):
         "No responses queued and no default response set\n\n",
     ]
     maxRequestLength = 1 * MEGABYTE
+    proxyRequestGen = collections.namedtuple("SpoofProxyRequest", "thread run")
     requestEnvGen = collections.namedtuple(
         "SpoofRequestEnv",
-        "content contentEncoding contentLength contentType headers "
-        "method path protocol queryString serverName serverPort uri",
+        "content contentEncoding contentLength contentType headers json"
+        " method path protocol queryString serverName serverPort uri",
     )
     requestReportQueue = None
     responseContentQueue = None
@@ -67,15 +69,16 @@ class HTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler, object):
         else:
             path = self.path
         env["path"] = urllib.parse.unquote(path)
+        env["json"] = functools.partial(json.loads, env["content"])
         requestEnv = self.requestEnvGen(**env)
-        self.requestReportQueue.put_nowait(requestEnv)
+        self.requestReportQueue.append(requestEnv)
         return requestEnv
 
     def nextResponse(self):
         """Returns next HTTP response to send."""
         try:
-            response = self.responseContentQueue.get_nowait()
-        except Queue.Empty:
+            response = self.responseContentQueue.popleft()
+        except IndexError:
             if self.defaultResponse is not None:
                 response = self.defaultResponse
             else:
@@ -91,11 +94,13 @@ class HTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler, object):
         contentLength = len(content) if content else 0
 
         self.send_response(statusCode)
+
         if content is not None:
             self.send_header("Content-Length", contentLength)
         for header in headers:
             self.send_header(*header)
         self.end_headers()
+
         if content:
             self.wfile.write(content)
 
@@ -129,20 +134,16 @@ class HTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler, object):
         """Handle CONNECT request, sending it upstream if successful."""
         _, response = self.handleRequest()
         if response[0] == HTTP_OK and self.server.upstream is not None:
-            if response[2]:
-                message = "CONNECT requests cannot have response content"
-                raise RuntimeError(message)
             self.proxyRequest()
 
     def proxyRequest(self):
-        """Simulate request proxying via threaded bi-directional socket copy,
-        with a ``threading.Event`` to synchronize I/O exceptions.
+        """Simulate request proxying via threaded bi-directional socket copy
+        to upstream ``spoof.HTTPServer`` instance with a ``threading.Event``
+        to synchronize I/O exceptions.
         """
         run = threading.Event()
         thread = threading.Thread(target=self._proxyRequest, name="proxyRequest", args=(run,))
-        self.server.upstream.proxyThreads.append(
-            collections.namedtuple("Request", "thread run")(thread, run)
-        )
+        self.server.upstream.proxyThreads.append(self.proxyRequestGen(thread, run))
         run.set()
         thread.start()
         thread.join()
@@ -155,10 +156,10 @@ class HTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler, object):
         writer = {downstream: upstream, upstream: downstream}
 
         while run.is_set():
-            read, _, _ = select.select(
+            ready_to_recv, _, _ = select.select(
                 [downstream, upstream], [], [], self.server.upstream.selectTimeout
             )
-            for sock in read:
+            for sock in ready_to_recv:
                 chunk = sock.recv(self.server.upstream.recvSize)
                 if not chunk:
                     run.clear()
@@ -168,23 +169,9 @@ class HTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler, object):
             sock.shutdown(socket.SHUT_WR)
             sock.close()
 
-    def handle_one_request(self, *args, **kwargs):
-        """Overrides base class to squelch TLSV1_ALERT_UNKNOWN_CA exception
-        stemming from the use of self-signed certificates.  The error will
-        be logged if self.debug is `True`.
-        """
-        try:
-            super(HTTPRequestHandler, self).handle_one_request(*args, **kwargs)
-        except ssl.SSLError as error:
-            if "TLSV1_ALERT_UNKNOWN_CA" in str(error):
-                self.log_error("SSL negotiation failed: %r", error)
-            else:
-                raise
-
     def log_message(self, *args, **kwargs):
-        """Overrides base class to squelch logging unless
-        self.debug is true.
-        """
+        """Overrides base class to squelch request logging unless self.debug is true."""
+
         if self.debug:
             super(HTTPRequestHandler, self).log_message(*args, **kwargs)
 
@@ -209,7 +196,8 @@ class HTTPServer(object):
         :timeout: integer timeout in seconds to wait for server operations
         :sslContext: `ssl.SSLContext` compatible instance
         """
-        self._requests = []
+        self._requests = collections.deque()
+        self._responses = collections.deque()
         self._sslContext = sslContext
         self._upstream = None
         self.handlerClass = self.configureHandlerClass(self.handlerClass)
@@ -304,10 +292,8 @@ class HTTPServer(object):
         used to effectively create a discrete handler class and attributes.
         """
         handlerClass = type(sourceClass.__name__, (sourceClass, object), dict())
-        self.responseContentQueue = Queue.Queue()
-        self.requestReportQueue = Queue.Queue()
-        handlerClass.responseContentQueue = self.responseContentQueue
-        handlerClass.requestReportQueue = self.requestReportQueue
+        handlerClass.responseContentQueue = self._responses
+        handlerClass.requestReportQueue = self._requests
         return handlerClass
 
     def start(self):
@@ -328,20 +314,19 @@ class HTTPServer(object):
         self.thread.start()
 
     def stop(self):
-        """Stops HTTP server and closes socket."""
+        """Stops HTTP server thread(s) and closes socket(s)."""
         for proxy in self.proxyThreads:
             proxy.run.clear()
             proxy.thread.join()
-        self.proxyThreads = []
-        if self.server is None:
-            message = "server at {0} already stopped".format(self.url)
-            raise RuntimeError(message)
-        self.server.shutdown()
-        self.server.server_close()
+        if self.server is not None:
+            self.server.shutdown()
+            self.server.server_close()
         if self.thread is not None:
             self.thread.join()
-            self.thread = None
+
+        self.proxyThreads = []
         self.server = None
+        self.thread = None
 
     def __enter__(self):
         """Starts HTTP server and returns `Spoof` instance when invoked as a
@@ -372,19 +357,13 @@ class HTTPServer(object):
 
     def reset(self):
         """Reset request and response attributes."""
-        queues = ["requestReportQueue", "responseContentQueue"]
-        for queue in [getattr(self, name) for name in queues]:
-            try:
-                while True:
-                    queue.get_nowait()
-            except Queue.Empty:
-                pass
-        del self._requests[:]
+        self._requests.clear()
+        self._responses.clear()
         self.defaultResponse = None
 
     @property
     def requests(self):
-        """Returns list of namedtuple request instances with the
+        """Returns ``deque`` of namedtuple instances with the
         following properties:
 
         :content:         string containing request content if present,
@@ -397,6 +376,7 @@ class HTTPServer(object):
         :headers:         `mimetools.Message` instance with all request
                           headers; to get specific header use:
                           `headers.get(headerName, defaultValue)`
+        :json():          Convenience to call json.loads on content
         :method:          Request method (e.g. GET, POST, HEAD)
         :path:            Decoded URI path, without query string
         :protocol:        Protocol version client used to send request
@@ -407,13 +387,25 @@ class HTTPServer(object):
         :serverPort:      TCP/IP port of server
         :uri:             Raw URI path and query string, if present
         """
-        try:
-            while True:
-                requestReport = self.requestReportQueue.get_nowait()
-                self._requests.append(requestReport)
-        except Queue.Empty:
-            pass
         return self._requests
+
+    @property
+    def responses(self):
+        """Returns ``deque`` of responses to send. If no responses are queued,
+        then ``self.defaultResponse`` is sent. If no default response is set,
+        then ``self.errorResponse`` is sent. Format for responses:
+
+        [httpStatus, [(headerName1, value1), (headerName2, value2)], content]
+
+        Example adding one response and multiple responses:
+
+        self.responses.append([200, [("Content-Type", "text/plain)], "OK"])
+        self.responses.extend([
+            [200, [("Content-Type", "text/plain)], "One"],
+            [200, [("Content-Type", "text/plain)], "Two"],
+        ])
+        """
+        return self._responses
 
     @property
     def maxRequestLength(self):
@@ -435,7 +427,7 @@ class HTTPServer(object):
         """Sets the default response used by the request handler class to
         respond to requests when no responses are queued. If the default
         response is not set, and no responses are queued, errorResponse
-        is sent.  Response format:
+        is sent. Format for response:
 
         [httpStatus, [(headerName1, value1), (headerName2, value2)], content]
 
@@ -453,14 +445,10 @@ class HTTPServer(object):
 
     def queueResponse(self, *responses):
         """Queues one or more response to be returned by HTTP server.
-        If no responses are queued, the handler class defaultResponse
-        will be sent. If defaultResponse is not set, and no responses
-        are queued, the errorResponse is sent.
 
-        See `defaultResponse` for response format.
+        NOTE: This method is deprecated. Please use ``responses`` instead.
         """
-        for response in responses:
-            self.responseContentQueue.put_nowait(response)
+        self._responses.extend(responses)
 
 
 class HTTPServer6(HTTPServer):
@@ -495,16 +483,25 @@ class SSLContext(object):
 
     @classmethod
     def createSelfSignedCert(
-        cls, commonName="localhost", bits=2048, days=365, openssl="openssl", subjectAltNames=None
+        cls,
+        commonName="localhost",
+        bits=2048,
+        days=365,
+        openssl="openssl",
+        subjectAltNames=None,
+        keyAlgorithm=None,
     ):
         """Creates and returns file paths to self-signed certificate and key
         via OpenSSL command line tool.
 
         :commonName: string of hostname for X509 certificate
-        :bits: RSA key length in bits
+        :bits: RSA public key length in bits
         :days: length in days certificate is valid
         :openssl: name/path string of openssl command
+        :keyAlgorithm: key algorithm to use (e.g. mldsa65); ignores ``bits`` arg
         """
+        if keyAlgorithm is None:
+            keyAlgorithm = "rsa:" + str(bits)
         devNull = open(os.devnull, "w")
         key = tempfile.mkstemp()
         cert = tempfile.mkstemp()
@@ -517,7 +514,7 @@ class SSLContext(object):
             "-config",
             config,
             "-newkey",
-            "rsa:" + str(bits),
+            keyAlgorithm,
             "-keyout",
             key[1],
             "-out",

--- a/tests/test_spoof_functional.py
+++ b/tests/test_spoof_functional.py
@@ -50,9 +50,11 @@ class TestRequest(BaseMixin):
 
     def tearDown(self):
         self.httpd.reset()
-        self.httpd6.reset()
         self.httpd.debug = False
+        self.httpd.maxRequestLength = spoof.MEGABYTE
+        self.httpd6.reset()
         self.httpd6.debug = False
+        self.httpd6.maxRequestLength = spoof.MEGABYTE
 
     def test_spoof_sends_response_status(self):
         self.assertEqual(self.response[0], self.result.status_code)
@@ -85,7 +87,7 @@ class TestRequest(BaseMixin):
     def test_spoof_returns_request_content(self):
         expected = json.loads(json.dumps(self.data))
         self.session.post(self.httpd.url + self.path, json=expected)
-        result = json.loads(self.httpd.requests[-1].content.decode("utf-8"))
+        result = self.httpd.requests[-1].json()
         self.assertEqual(expected, result)
 
     def test_spoof_returns_request_contentEncoding(self):
@@ -183,6 +185,33 @@ class TestRequest(BaseMixin):
         self.httpd.defaultResponse = [200, [], None]
         response = self.session.get(self.httpd.url)
         self.assertIsNone(response.headers.get("Content-Length"))
+
+    def test_maxRequestLength_is_honored(self):
+        self.httpd.maxRequestLength = 1
+        response = self.session.post(self.httpd.url, data=b"OK")
+        expected = spoof.HTTP_REQUEST_ENTITY_TOO_LARGE
+        result = response.status_code
+        self.assertEqual(expected, result)
+
+    def test_queue_single_response(self):
+        expected = "One fish"
+        self.httpd.responses.append([200, [], expected])
+        response = self.session.get(self.httpd.url)
+        result = response.text
+        self.assertEqual(expected, result)
+
+    def test_queueing_multiple_responses(self):
+        expected = ["One fish", "Two fish", "Red fish", "Blue fish"]
+        self.httpd.responses.extend([[200, [], text] for text in expected])
+        results = [self.session.get(self.httpd.url).text for _ in expected]
+        self.assertEqual(expected, results)
+
+    def test_queue_callback(self):
+        expected_path = "/correct/horse/battery/staple"
+        self.httpd.responses.append(lambda request: [200, [], request.path])
+        response = self.session.get(self.httpd.url + expected_path)
+        self.assertEqual(expected_path, response.text)
+        self.assertEqual(expected_path, self.httpd.requests[-1].path)
 
 
 class TestProxy(BaseMixin):

--- a/tests/test_spoof_unit.py
+++ b/tests/test_spoof_unit.py
@@ -30,24 +30,12 @@ class TestHTTPRequestHandler(unittest.TestCase):
 
         mock.patch.object(spoof.HTTPRequestHandler, "__init__", fakeInit).start()
         self.handler = spoof.HTTPRequestHandler()
-        self.mockRequestQueue = mock.patch.object(
-            spoof.HTTPRequestHandler, "requestReportQueue", spec=spoof.Queue.Queue
-        ).start()
-        self.mockResponseQueue = mock.patch.object(
-            spoof.HTTPRequestHandler, "responseContentQueue", spec=spoof.Queue.Queue
-        ).start()
 
     def tearDown(self):
         self.rfile = None
         self.wfile = None
         self.handler = None
         mock.patch.stopall()
-
-    def test_Handler_reportRequestEnv_does_not_catch_AssertionError(self):
-        error = AssertionError
-        with self.assertRaises(error):
-            self.mockRequestQueue.put_nowait.side_effect = error("raised")
-            self.handler.reportRequestEnv()
 
     def test_Handler_sendResponse_handles_empty_response(self):
         status = spoof.HTTP_REQUEST_ENTITY_TOO_LARGE
@@ -57,30 +45,9 @@ class TestHTTPRequestHandler(unittest.TestCase):
         formattedStatus = " {0} ".format(status)
         self.assertIn(formattedStatus, response)
 
-    @mock.patch.object(spoof.HTTPRequestHandler, "sendResponse")
-    def test_Handler_handleRequest_honors_maxRequestLength(self, mockSend):
-        self.mockResponseQueue.get_nowait.return_value = [200, [], "OK"]
-        self.handler.maxRequestLength = 1
-        self.handler.handleRequest()
-        expected = spoof.HTTP_REQUEST_ENTITY_TOO_LARGE
-        result = mockSend.call_args[0][0][0]
-        self.assertEqual(expected, result)
-
     def test_Handler_raises_AttributeError_for_unknown_attributes(self):
         with self.assertRaises(AttributeError):
             self.handler.attributeThatDoesNotExist
-
-    @mock.patch.object(spoof.BaseHTTPServer.BaseHTTPRequestHandler, "handle_one_request")
-    def test_Handler_handle_one_reequest_catches_UNKNOWN_CA_SSLError(self, mockOne):
-        mockOne.side_effect = spoof.ssl.SSLError("TLSV1_ALERT_UNKNOWN_CA")
-        self.handler.handle_one_request()
-        self.assertTrue(mockOne.called)
-
-    @mock.patch.object(spoof.BaseHTTPServer.BaseHTTPRequestHandler, "handle_one_request")
-    def test_Handler_handle_one_reequest_doesnt_catch_OTHER_SSLError(self, mockOne):
-        mockOne.side_effect = spoof.ssl.SSLError("TLSV1_ALERT_OTHER_CA")
-        with self.assertRaises(spoof.ssl.SSLError):
-            self.handler.handle_one_request()
 
     @mock.patch.object(spoof.BaseHTTPServer.BaseHTTPRequestHandler, "log_message")
     def test_Handler_log_message_called_with_debug_true(self, mockLog):
@@ -96,12 +63,6 @@ class TestHTTPRequestHandler(unittest.TestCase):
         self.handler.log_message(message)
         self.assertFalse(mockLog.called)
 
-    @mock.patch.object(spoof.HTTPRequestHandler, "handleRequest")
-    def test_Handler_raises_exception_on_CONNECT_with_content(self, mock_req):
-        mock_req.return_value = (None, (200, (), "Not empty string"))
-        with self.assertRaises(RuntimeError):
-            self.handler.do_CONNECT()
-
 
 class TestHTTPServer(unittest.TestCase):
     def setUp(self):
@@ -115,10 +76,6 @@ class TestHTTPServer(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self.httpd.start()
             self.httpd.start()
-
-    def test_Server_raises_RuntimeError_if_already_stopped(self):
-        with self.assertRaises(RuntimeError):
-            self.httpd.stop()
 
     def test_Server_context_manager_returns_HTTPServer_instance(self):
         with spoof.HTTPServer() as httpd:
@@ -136,17 +93,6 @@ class TestHTTPServer(unittest.TestCase):
     def test_Server_defaultResponse_returns_None(self):
         result = self.httpd.defaultResponse
         self.assertIsNone(result)
-
-    def test_Server_defaultResponse_can_be_set(self):
-        expected = [200, [], "OK"]
-        self.httpd.defaultResponse = expected
-        result = self.httpd.defaultResponse
-        self.assertEqual(expected, result)
-
-    def test_Server_get_timeout(self):
-        expected = self.httpd.serverClass.timeout
-        result = self.httpd.timeout
-        self.assertEqual(expected, result)
 
     def test_Server_set_timeout(self):
         expected = random.randint(1, 300)
@@ -167,32 +113,6 @@ class TestHTTPServer(unittest.TestCase):
         with spoof.HTTPServer() as httpd:
             httpd.timeout = expected
             result = httpd.server.timeout
-            self.assertEqual(expected, result)
-
-    def test_Server_get_upstream(self):
-        expected = None
-        result = self.httpd.upstream
-        self.assertEqual(expected, result)
-
-    def test_Server_set_upstream(self):
-        expected = True
-        self.httpd.upstream = expected
-        result = self.httpd.upstream
-        self.assertEqual(expected, result)
-
-    def test_Server_get_upstream_gets_server_instance(self):
-        randupstream = True
-        with spoof.HTTPServer() as httpd:
-            httpd.upstream = randupstream
-            expected = httpd.server.upstream
-            result = httpd.upstream
-            self.assertEqual(expected, result)
-
-    def test_Server_set_upstream_sets_server_instance(self):
-        expected = True
-        with spoof.HTTPServer() as httpd:
-            httpd.upstream = expected
-            result = httpd.server.upstream
             self.assertEqual(expected, result)
 
 


### PR DESCRIPTION
* Replace queues with deques for a simpler interface, allowing use of
  ``.append()`` and ``.extend()`` methods for requests and responses
* Add ``.json()`` convenience function to request objects
* Add ``.responses`` property to compliment ``.requests`` property
* Add ``keyAlgorithm`` arg to ``createSelfSignedCert`` to allow for non-RSA keys, including post quantum algorithms like mldsa65
* Remove unnecessary content check for CONNECT method
* Deprecate ``.queueResponse`` method
* Remove unused code
* Update tests
* Update docs